### PR TITLE
Fix whitespace parsing in substitution parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.0.2
+
+- Fix bug with parsing whitespace in params
+    - allow for whitespace in the susbstitution parameter so that
+      {name} = { name }
+    - match based on the name only, but highlight the whole text of
+      the parameter when there is an error
+
 ### v1.0.1
 
 - updated dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint-python",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "main": "./src/index.js",
     "type": "module",
     "exports": {

--- a/src/FStringMatchRule.js
+++ b/src/FStringMatchRule.js
@@ -21,7 +21,7 @@ import Locale from 'ilib-locale';
 import { Rule, Result } from 'i18nlint-common';
 
 // from https://peps.python.org/pep-0498/
-const fstringRegExp = /\{(\}\}|[^}])*?\}/g;
+const fstringRegExp = /\{\s*((\}\}|[^}])*?)\s*\}/g;
 
 /**
  * @class Represent an i18nlint rule.
@@ -54,7 +54,8 @@ class FStringMatchRule extends Rule {
         while (match) {
             sourceParams.push({
                 text: match[0],
-                number: match[1]
+                name: match[1],
+                number: match[2]
             });
             match = fstringRegExp.exec(src);
         }
@@ -69,7 +70,8 @@ class FStringMatchRule extends Rule {
         while (match) {
             targetParams.push({
                 text: match[0],
-                number: match[1]
+                name: match[1],
+                number: match[2]
             });
             match = fstringRegExp.exec(tar);
         }
@@ -80,7 +82,7 @@ class FStringMatchRule extends Rule {
             let found = false;
             for (let j = 0; j < targetParams.length; j++) {
                 const tarParam = targetParams[j];
-                if (tarParam.text === srcParam.text && tarParam.number === srcParam.number) {
+                if (tarParam.name === srcParam.name && tarParam.number === srcParam.number) {
                     targetParams.splice(j, 1);
                     found = true;
                     break;

--- a/src/LegacyMatchRule.js
+++ b/src/LegacyMatchRule.js
@@ -21,7 +21,7 @@ import Locale from 'ilib-locale';
 import { Rule, Result } from 'i18nlint-common';
 
 // from https://pubs.opengroup.org/onlinepubs/007904975/functions/fprintf.html
-const printfRegExp = /%\(\w+\)?[\-\+ #0']*[\d\*]?(\.(\d*|\*))?(hh?|ll?|j|z|t|L)?[diouxXfFeEgGaAcCsSpn]/g;
+const printfRegExp = /%\(\s*(\w+)\s*\)?[\-\+ #0']*[\d\*]?(\.(\d*|\*))?(hh?|ll?|j|z|t|L)?[diouxXfFeEgGaAcCsSpn]/g;
 
 /**
  * @class Represent an i18nlint rule.
@@ -56,7 +56,8 @@ class LegacyMatchRule extends Rule {
         while (match) {
             sourceParams.push({
                 text: match[0],
-                number: match[1]
+                name: match[1],
+                number: match[2]
             });
             match = printfRegExp.exec(src);
         }
@@ -67,7 +68,8 @@ class LegacyMatchRule extends Rule {
         while (match) {
             targetParams.push({
                 text: match[0],
-                number: match[1]
+                name: match[1],
+                number: match[2]
             });
             match = printfRegExp.exec(tar);
         }
@@ -78,7 +80,7 @@ class LegacyMatchRule extends Rule {
             let found = false;
             for (let j = 0; j < targetParams.length; j++) {
                 const tarParam = targetParams[j];
-                if (tarParam.text === srcParam.text && tarParam.number === srcParam.number) {
+                if (tarParam.name === srcParam.name && tarParam.number === srcParam.number) {
                     targetParams.splice(j, 1);
                     found = true;
                     break;

--- a/test/testFStringMatchRule.js
+++ b/test/testFStringMatchRule.js
@@ -200,7 +200,7 @@ export const testFStringMatchRules = {
         const rule = new FStringMatchRule();
         test.ok(rule);
 
-        // no parameters in source or target is okay
+        // whitespace in parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
             resource: new ResourceString({
@@ -224,7 +224,7 @@ export const testFStringMatchRules = {
         const rule = new FStringMatchRule();
         test.ok(rule);
 
-        // no parameters in source or target is okay
+        // whitespace in parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
             resource: new ResourceString({

--- a/test/testFStringMatchRule.js
+++ b/test/testFStringMatchRule.js
@@ -194,6 +194,54 @@ export const testFStringMatchRules = {
         test.done();
     },
 
+    testFStringMatchRuleMatchMatchingParamsIgnoreWhitespaceInSource: function(test) {
+        test.expect(2);
+
+        const rule = new FStringMatchRule();
+        test.ok(rule);
+
+        // no parameters in source or target is okay
+        const actual = rule.match({
+            locale: "de-DE",
+            resource: new ResourceString({
+                key: "printf.test",
+                sourceLocale: "en-US",
+                source: 'This string contains { name } in it.',
+                targetLocale: "de-DE",
+                target: 'Diese Zeichenfolge enthält {name}.',
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testFStringMatchRuleMatchMatchingParamsIgnoreWhitespaceInTarget: function(test) {
+        test.expect(2);
+
+        const rule = new FStringMatchRule();
+        test.ok(rule);
+
+        // no parameters in source or target is okay
+        const actual = rule.match({
+            locale: "de-DE",
+            resource: new ResourceString({
+                key: "printf.test",
+                sourceLocale: "en-US",
+                source: 'This string contains {name} in it.',
+                targetLocale: "de-DE",
+                target: 'Diese Zeichenfolge enthält { name }.',
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
     testFStringMatchRuleMatchMatchingParamsMultiple: function(test) {
         test.expect(2);
 

--- a/test/testLegacyMatchRule.js
+++ b/test/testLegacyMatchRule.js
@@ -211,7 +211,7 @@ export const testLegacyMatchRules = {
         const rule = new LegacyMatchRule();
         test.ok(rule);
 
-        // no parameters in source or target is okay
+        // whitespace in parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
             resource: new ResourceString({
@@ -235,7 +235,7 @@ export const testLegacyMatchRules = {
         const rule = new LegacyMatchRule();
         test.ok(rule);
 
-        // no parameters in source or target is okay
+        // whitespace in parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
             resource: new ResourceString({

--- a/test/testLegacyMatchRule.js
+++ b/test/testLegacyMatchRule.js
@@ -205,6 +205,54 @@ export const testLegacyMatchRules = {
         test.done();
     },
 
+    testLegacyMatchRuleMatchMatchingParamsIgnoreWhitespaceInSource: function(test) {
+        test.expect(2);
+
+        const rule = new LegacyMatchRule();
+        test.ok(rule);
+
+        // no parameters in source or target is okay
+        const actual = rule.match({
+            locale: "de-DE",
+            resource: new ResourceString({
+                key: "printf.test",
+                sourceLocale: "en-US",
+                source: 'This string contains %( name )s in it.',
+                targetLocale: "de-DE",
+                target: 'Diese Zeichenfolge enthält %(name)s.',
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testLegacyMatchRuleMatchMatchingParamsIgnoreWhitespaceInTarget: function(test) {
+        test.expect(2);
+
+        const rule = new LegacyMatchRule();
+        test.ok(rule);
+
+        // no parameters in source or target is okay
+        const actual = rule.match({
+            locale: "de-DE",
+            resource: new ResourceString({
+                key: "printf.test",
+                sourceLocale: "en-US",
+                source: 'This string contains %(name)s in it.',
+                targetLocale: "de-DE",
+                target: 'Diese Zeichenfolge enthält %( name )s.',
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
     testLegacyMatchRuleMatchMatchingParamsMultiple: function(test) {
         test.expect(2);
 


### PR DESCRIPTION
- Fix bug with parsing whitespace in params
    - allow for whitespace in the susbstitution parameter so that {name} = { name }
    - match based on the name only, but highlight the whole text of the parameter when there is an error