### PR TITLE
Fix problem where numeric substitution parameters caused exceptions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.0.3
+
+- Fixed a bug where a numeric parameter in the target FString, such as
+  "{0}" would cause an exception
+
 ### v1.0.2
 
 - Fix bug with parsing whitespace in params

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint-python",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "main": "./src/index.js",
     "type": "module",
     "exports": {

--- a/src/FStringMatchRule.js
+++ b/src/FStringMatchRule.js
@@ -28,14 +28,14 @@ const fstringRegExp = /\{\s*((\}\}|[^}])*?)\s*\}/g;
  */
 function escapeRegex(re) {
     return re.
-        replaceAll(/\{/g, "\\{").
-        replaceAll(/\}/g, "\\}").
-        replaceAll(/\[/g, "\\[").
-        replaceAll(/\]/g, "\\]").
-        replaceAll(/\./g, "\\.").
-        replaceAll(/\?/g, "\\?").
-        replaceAll(/\*/g, "\\*").
-        replaceAll(/\+/g, "\\+");
+        replace(/\{/g, "\\{").
+        replace(/\}/g, "\\}").
+        replace(/\[/g, "\\[").
+        replace(/\]/g, "\\]").
+        replace(/\./g, "\\.").
+        replace(/\?/g, "\\?").
+        replace(/\*/g, "\\*").
+        replace(/\+/g, "\\+");
 }
 
 /**

--- a/src/FStringMatchRule.js
+++ b/src/FStringMatchRule.js
@@ -24,6 +24,21 @@ import { Rule, Result } from 'i18nlint-common';
 const fstringRegExp = /\{\s*((\}\}|[^}])*?)\s*\}/g;
 
 /**
+ * @private
+ */
+function escapeRegex(re) {
+    return re.
+        replaceAll(/\{/g, "\\{").
+        replaceAll(/\}/g, "\\}").
+        replaceAll(/\[/g, "\\[").
+        replaceAll(/\]/g, "\\]").
+        replaceAll(/\./g, "\\.").
+        replaceAll(/\?/g, "\\?").
+        replaceAll(/\*/g, "\\*").
+        replaceAll(/\+/g, "\\+");
+}
+
+/**
  * @class Represent an i18nlint rule.
  */
 class FStringMatchRule extends Rule {
@@ -104,7 +119,7 @@ class FStringMatchRule extends Rule {
         if (targetParams.length) {
             for (let j = 0; j < targetParams.length; j++) {
                 const tarParam = targetParams[j];
-                const re = new RegExp(tarParam.text, "g");
+                const re = new RegExp(escapeRegex(tarParam.text), "g");
                 problems.push(new Result({
                     severity: "error",
                     rule: this,

--- a/src/FStringMatchRule.js
+++ b/src/FStringMatchRule.js
@@ -27,15 +27,7 @@ const fstringRegExp = /\{\s*((\}\}|[^}])*?)\s*\}/g;
  * @private
  */
 function escapeRegex(re) {
-    return re.
-        replace(/\{/g, "\\{").
-        replace(/\}/g, "\\}").
-        replace(/\[/g, "\\[").
-        replace(/\]/g, "\\]").
-        replace(/\./g, "\\.").
-        replace(/\?/g, "\\?").
-        replace(/\*/g, "\\*").
-        replace(/\+/g, "\\+");
+    return re.replace(/([\{\}\[\]\.\?\*\+\(\)\|\\])/g, "\\$1");
 }
 
 /**

--- a/test/testFStringMatchRule.js
+++ b/test/testFStringMatchRule.js
@@ -378,18 +378,18 @@ export const testFStringMatchRules = {
             file: "x"
         });
         test.ok(actual);
-       
+
         // if the source contains native quotes, the target must too
         const expected = [
-	        new Result({
-	            severity: "error",
-	            description: "Source string substitution parameter {0} not found in the target string.",
-	            id: "printf.test",
-	            source: 'This string contains {0} in it.',
-	            highlight: '<e0>Diese Zeichenfolge enthält {name}.</e0>',
-	            rule,
-	            pathName: "x"
-	        }),
+            new Result({
+                severity: "error",
+                description: "Source string substitution parameter {0} not found in the target string.",
+                id: "printf.test",
+                source: 'This string contains {0} in it.',
+                highlight: '<e0>Diese Zeichenfolge enthält {name}.</e0>',
+                rule,
+                pathName: "x"
+            }),
             new Result({
                 severity: "error",
                 description: "Extra target string substitution parameter {name} not found in the source string.",
@@ -399,7 +399,7 @@ export const testFStringMatchRules = {
                 rule,
                 pathName: "x"
             }),
-	    ];
+        ];
         test.deepEqual(actual, expected);
 
         test.done();
@@ -425,14 +425,14 @@ export const testFStringMatchRules = {
             file: "x"
         });
         test.ok(actual);
-       
+
         // if the source contains native quotes, the target must too
         const expected = [
             new Result({
                 severity: "error",
                 description: "Source string substitution parameter {name} not found in the target string.",
                 id: "printf.test",
-                source: 'This string contains {0} in it.',
+                source: 'This string contains {name} in it.',
                 highlight: '<e0>Diese Zeichenfolge enthält {0}.</e0>',
                 rule,
                 pathName: "x"
@@ -441,7 +441,7 @@ export const testFStringMatchRules = {
                 severity: "error",
                 description: "Extra target string substitution parameter {0} not found in the source string.",
                 id: "printf.test",
-                source: 'This string contains {0} in it.',
+                source: 'This string contains {name} in it.',
                 highlight: 'Diese Zeichenfolge enthält <e0>{0}</e0>.',
                 rule,
                 pathName: "x"

--- a/test/testFStringMatchRule.js
+++ b/test/testFStringMatchRule.js
@@ -364,7 +364,6 @@ export const testFStringMatchRules = {
         const rule = new FStringMatchRule();
         test.ok(rule);
 
-        // numeric params in source and target is okay
         const actual = rule.match({
             locale: "de-DE",
             resource: new ResourceString({
@@ -379,7 +378,6 @@ export const testFStringMatchRules = {
         });
         test.ok(actual);
 
-        // if the source contains native quotes, the target must too
         const expected = [
             new Result({
                 severity: "error",
@@ -411,7 +409,6 @@ export const testFStringMatchRules = {
         const rule = new FStringMatchRule();
         test.ok(rule);
 
-        // numeric params in source and target is okay
         const actual = rule.match({
             locale: "de-DE",
             resource: new ResourceString({
@@ -426,7 +423,6 @@ export const testFStringMatchRules = {
         });
         test.ok(actual);
 
-        // if the source contains native quotes, the target must too
         const expected = [
             new Result({
                 severity: "error",
@@ -450,6 +446,6 @@ export const testFStringMatchRules = {
         test.deepEqual(actual, expected);
 
         test.done();
-    },
+    }
 };
 

--- a/test/testFStringMatchRule.js
+++ b/test/testFStringMatchRule.js
@@ -332,6 +332,124 @@ export const testFStringMatchRules = {
         test.deepEqual(actual, expected);
 
         test.done();
-    }
+    },
+
+    testFStringMatchRuleMatchNumericParams: function(test) {
+        test.expect(2);
+
+        const rule = new FStringMatchRule();
+        test.ok(rule);
+
+        // numeric params in source and target is okay
+        const actual = rule.match({
+            locale: "de-DE",
+            resource: new ResourceString({
+                key: "printf.test",
+                sourceLocale: "en-US",
+                source: 'This string contains {0} in it.',
+                targetLocale: "de-DE",
+                target: 'Diese Zeichenfolge enthält {0}.',
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testFStringMatchRuleNonMatchNumericParams: function(test) {
+        test.expect(3);
+
+        const rule = new FStringMatchRule();
+        test.ok(rule);
+
+        // numeric params in source and target is okay
+        const actual = rule.match({
+            locale: "de-DE",
+            resource: new ResourceString({
+                key: "printf.test",
+                sourceLocale: "en-US",
+                source: 'This string contains {0} in it.',
+                targetLocale: "de-DE",
+                target: 'Diese Zeichenfolge enthält {name}.',
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x"
+        });
+        test.ok(actual);
+       
+        // if the source contains native quotes, the target must too
+        const expected = [
+	        new Result({
+	            severity: "error",
+	            description: "Source string substitution parameter {0} not found in the target string.",
+	            id: "printf.test",
+	            source: 'This string contains {0} in it.',
+	            highlight: '<e0>Diese Zeichenfolge enthält {name}.</e0>',
+	            rule,
+	            pathName: "x"
+	        }),
+            new Result({
+                severity: "error",
+                description: "Extra target string substitution parameter {name} not found in the source string.",
+                id: "printf.test",
+                source: 'This string contains {0} in it.',
+                highlight: 'Diese Zeichenfolge enthält <e0>{name}</e0>.',
+                rule,
+                pathName: "x"
+            }),
+	    ];
+        test.deepEqual(actual, expected);
+
+        test.done();
+    },
+
+    testFStringMatchRuleNonMatchNumericTargetParams: function(test) {
+        test.expect(3);
+
+        const rule = new FStringMatchRule();
+        test.ok(rule);
+
+        // numeric params in source and target is okay
+        const actual = rule.match({
+            locale: "de-DE",
+            resource: new ResourceString({
+                key: "printf.test",
+                sourceLocale: "en-US",
+                source: 'This string contains {name} in it.',
+                targetLocale: "de-DE",
+                target: 'Diese Zeichenfolge enthält {0}.',
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x"
+        });
+        test.ok(actual);
+       
+        // if the source contains native quotes, the target must too
+        const expected = [
+            new Result({
+                severity: "error",
+                description: "Source string substitution parameter {name} not found in the target string.",
+                id: "printf.test",
+                source: 'This string contains {0} in it.',
+                highlight: '<e0>Diese Zeichenfolge enthält {0}.</e0>',
+                rule,
+                pathName: "x"
+            }),
+            new Result({
+                severity: "error",
+                description: "Extra target string substitution parameter {0} not found in the source string.",
+                id: "printf.test",
+                source: 'This string contains {0} in it.',
+                highlight: 'Diese Zeichenfolge enthält <e0>{0}</e0>.',
+                rule,
+                pathName: "x"
+            }),
+        ];
+        test.deepEqual(actual, expected);
+
+        test.done();
+    },
 };
 


### PR DESCRIPTION
In the section where we checked whether or not the source substitution parameters also appear in the target, we need to escape characters that could be confused as regular expression syntax.