### PR TITLE
Update dependencies and update to i18nlint-common 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.0.4
+
+- updated dependencies
+
 ### v1.0.3
 
 - Fixed a bug where a numeric parameter in the target FString, such as

--- a/README.md
+++ b/README.md
@@ -69,9 +69,11 @@ limitations under the License.
 
 ## Release Notes
 
-### v1.0.4
+### v1.1.0
 
 - updated dependencies
+- update to i18nlint-common 2.x which requires the use of an intermediate
+  representation
 
 ### v1.0.3
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint-python",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "main": "./src/index.js",
     "type": "module",
     "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint-python",
-    "version": "1.0.4",
+    "version": "1.1.0",
     "main": "./src/index.js",
     "type": "module",
     "exports": {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
         "npm-run-all": "^4.1.5"
     },
     "dependencies": {
-        "i18nlint-common": "^1.3.0",
+        "i18nlint-common": "^2.1.0",
         "ilib-locale": "^1.2.2",
-        "ilib-tools-common": "^1.4.0"
+        "ilib-tools-common": "^1.7.0"
     }
 }

--- a/src/FStringMatchRule.js
+++ b/src/FStringMatchRule.js
@@ -125,53 +125,59 @@ class FStringMatchRule extends Rule {
             }
         }
 
-        return problems.length < 2 ? problems[0] : problems;
+        return problems;
     }
 
     /**
      * @override
      */
     match(options) {
-        const { resource, file, locale } = options;
+        const { ir, locale } = options;
         let problems = [];
 
-        switch (resource.getType()) {
-            case 'string':
-                const tarString = resource.getTarget();
-                if (tarString) {
-                    return this.checkString(resource.getSource(), tarString, file, resource, options.lineNumber);
-                }
-                break;
+        if (ir.getType() !== "resource") return;  // we can only process resources
+        const resources = ir.getRepresentation();
 
-            case 'array':
-                const srcArray = resource.getSource();
-                const tarArray = resource.getTarget();
-                if (tarArray) {
-                    return srcArray.map((item, i) => {
-                        if (i < tarArray.length && tarArray[i]) {
-                            return this.checkString(srcArray[i], tarArray[i], file, resource, options.lineNumber);
-                        }
-                    }).flat().filter(element => {
-                        return element;
-                    });
-                }
-                break;
+        const results = resources.flatMap(resource => {
+            switch (resource.getType()) {
+                case 'string':
+                    const tarString = resource.getTarget();
+                    if (tarString) {
+                        return this.checkString(resource.getSource(), tarString, ir.getPath(), resource, options.lineNumber);
+                    }
+                    break;
 
-            case 'plural':
-                const srcPlural = resource.getSource();
-                const tarPlural = resource.getTarget();
-                if (tarPlural) {
-                    const categories = Array.from(new Set(Object.keys(srcPlural).concat(Object.keys(tarPlural))).values());
-                    return categories.map(category => {
-                        return this.checkString(srcPlural[category] || srcPlural.other, tarPlural[category] || tarPlural.other, file, resource, options.lineNumber);
-                    }).flat();
-                }
-                break;
-        }
+                case 'array':
+                    const srcArray = resource.getSource();
+                    const tarArray = resource.getTarget();
+                    if (tarArray) {
+                        return srcArray.flatMap((item, i) => {
+                            if (i < tarArray.length && tarArray[i]) {
+                                return this.checkString(srcArray[i], tarArray[i], ir.getPath(), resource, options.lineNumber);
+                            }
+                        }).filter(element => {
+                            return element;
+                        });
+                    }
+                    break;
+
+                case 'plural':
+                    const srcPlural = resource.getSource();
+                    const tarPlural = resource.getTarget();
+                    if (tarPlural) {
+                        const categories = Array.from(new Set(Object.keys(srcPlural).concat(Object.keys(tarPlural))).values());
+                        return categories.flatMap(category => {
+                            return this.checkString(srcPlural[category] || srcPlural.other, tarPlural[category] || tarPlural.other, ir.getPath(), resource, options.lineNumber);
+                        });
+                    }
+                    break;
+            }
+
+            // no match
+            return [];
+        });
+        return results.length > 1 ? results : results[0];
     }
-
-    // no match
-    return;
 }
 
 export default FStringMatchRule;

--- a/test/testFStringMatchRule.js
+++ b/test/testFStringMatchRule.js
@@ -20,7 +20,7 @@ import { ResourceString } from 'ilib-tools-common';
 
 import FStringMatchRule from '../src/FStringMatchRule.js';
 
-import { Result } from 'i18nlint-common';
+import { Result, IntermediateRepresentation } from 'i18nlint-common';
 
 export const testFStringMatchRules = {
     testFStringMatchRuleStyle: function(test) {
@@ -88,15 +88,18 @@ export const testFStringMatchRules = {
 
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains a {name} string in it.',
-                targetLocale: "de-DE",
-                target: "Diese Zeichenfolge enthält keinen anderen Zeichenfolgen.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains a {name} string in it.',
+                    targetLocale: "de-DE",
+                    target: "Diese Zeichenfolge enthält keinen anderen Zeichenfolgen.",
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         // if the source contains native quotes, the target must too
         const expected = new Result({
@@ -122,15 +125,18 @@ export const testFStringMatchRules = {
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains “quotes” in it.',
-                targetLocale: "de-DE",
-                target: 'Diese Zeichenfolge enthält "Anführungszeichen".',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains “quotes” in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält "Anführungszeichen".',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 
@@ -145,15 +151,18 @@ export const testFStringMatchRules = {
 
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains a {name} string in it.',
-                targetLocale: "de-DE",
-                target: "Diese Zeichenfolge enthält {name} anderen Zeichenfolgen {name}.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains a {name} string in it.',
+                    targetLocale: "de-DE",
+                    target: "Diese Zeichenfolge enthält {name} anderen Zeichenfolgen {name}.",
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         // if the source contains native quotes, the target must too
         const expected = new Result({
@@ -179,15 +188,18 @@ export const testFStringMatchRules = {
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains {name} in it.',
-                targetLocale: "de-DE",
-                target: 'Diese Zeichenfolge enthält {name}.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains {name} in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält {name}.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 
@@ -203,15 +215,18 @@ export const testFStringMatchRules = {
         // whitespace in parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains { name } in it.',
-                targetLocale: "de-DE",
-                target: 'Diese Zeichenfolge enthält {name}.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains { name } in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält {name}.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 
@@ -227,15 +242,18 @@ export const testFStringMatchRules = {
         // whitespace in parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains {name} in it.',
-                targetLocale: "de-DE",
-                target: 'Diese Zeichenfolge enthält { name }.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains {name} in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält { name }.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 
@@ -251,15 +269,18 @@ export const testFStringMatchRules = {
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string {number} contains {name} in it.',
-                targetLocale: "de-DE",
-                target: 'Diese Zeichenfolge enthält {name} {number}.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string {number} contains {name} in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält {name} {number}.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 
@@ -275,15 +296,18 @@ export const testFStringMatchRules = {
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains {number:.3d} in it.',
-                targetLocale: "de-DE",
-                target: 'Diese Zeichenfolge enthält {number:.3d}.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains {number:.3d} in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält {number:.3d}.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 
@@ -299,15 +323,18 @@ export const testFStringMatchRules = {
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains {number:.3d} in it.',
-                targetLocale: "de-DE",
-                target: 'Diese Zeichenfolge enthält {number:3.3d}.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains {number:.3d} in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält {number:3.3d}.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         const expected = [
             new Result({
@@ -343,15 +370,18 @@ export const testFStringMatchRules = {
         // numeric params in source and target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains {0} in it.',
-                targetLocale: "de-DE",
-                target: 'Diese Zeichenfolge enthält {0}.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains {0} in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält {0}.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 
@@ -366,15 +396,18 @@ export const testFStringMatchRules = {
 
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains {0} in it.',
-                targetLocale: "de-DE",
-                target: 'Diese Zeichenfolge enthält {name}.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains {0} in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält {name}.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(actual);
 
@@ -411,15 +444,18 @@ export const testFStringMatchRules = {
 
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains {name} in it.',
-                targetLocale: "de-DE",
-                target: 'Diese Zeichenfolge enthält {0}.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains {name} in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält {0}.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(actual);
 

--- a/test/testFStringNumberedRule.js
+++ b/test/testFStringNumberedRule.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import { ResourceString } from 'ilib-tools-common';
-import { Result } from 'i18nlint-common';
+import { Result, IntermediateRepresentation } from 'i18nlint-common';
 
 import FStringNumberedRule from '../src/FStringNumberedRule.js';
 
@@ -87,13 +87,16 @@ export const testFStringNumberedRules = {
 
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "fstring.test",
-                sourceLocale: "en-US",
-                source: 'This {} string contains a {} string in it.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "fstring.test",
+                    sourceLocale: "en-US",
+                    source: 'This {} string contains a {} string in it.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         // if the source contains native quotes, the target must too
         const expected = [
@@ -128,13 +131,16 @@ export const testFStringNumberedRules = {
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "fstring.test",
-                sourceLocale: "en-US",
-                source: 'This string contains no substitution parameters in it.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "fstring.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains no substitution parameters in it.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 
@@ -150,13 +156,16 @@ export const testFStringNumberedRules = {
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "fstring.test",
-                sourceLocale: "en-US",
-                source: 'This string contains a {name} substitution parameter in it.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "fstring.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains a {name} substitution parameter in it.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 
@@ -172,13 +181,16 @@ export const testFStringNumberedRules = {
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "fstring.test",
-                sourceLocale: "en-US",
-                source: 'This string contains a {} substitution parameter in it.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "fstring.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains a {} substitution parameter in it.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 
@@ -193,13 +205,16 @@ export const testFStringNumberedRules = {
 
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "fstring.test",
-                sourceLocale: "en-US",
-                source: 'This {name} string contains a {} string in it.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "fstring.test",
+                    sourceLocale: "en-US",
+                    source: 'This {name} string contains a {} string in it.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         // if the source contains native quotes, the target must too
         const expected = new Result({
@@ -223,13 +238,16 @@ export const testFStringNumberedRules = {
 
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "fstring.test",
-                sourceLocale: "en-US",
-                source: 'This {name} string contains a {} string in {location}.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "fstring.test",
+                    sourceLocale: "en-US",
+                    source: 'This {name} string contains a {} string in {location}.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         // if the source contains native quotes, the target must too
         const expected = new Result({
@@ -253,13 +271,16 @@ export const testFStringNumberedRules = {
 
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "fstring.test",
-                sourceLocale: "en-US",
-                source: 'This {name} string contains a {} string in {}.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "fstring.test",
+                    sourceLocale: "en-US",
+                    source: 'This {name} string contains a {} string in {}.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         // if the source contains native quotes, the target must too
         const expected = [

--- a/test/testLegacyMatchRule.js
+++ b/test/testLegacyMatchRule.js
@@ -20,7 +20,7 @@ import { ResourceString } from 'ilib-tools-common';
 
 import LegacyMatchRule from '../src/LegacyMatchRule.js';
 
-import { Result } from 'i18nlint-common';
+import { Result, IntermediateRepresentation } from 'i18nlint-common';
 
 export const testLegacyMatchRules = {
     testLegacyMatchRuleStyle: function(test) {
@@ -88,15 +88,18 @@ export const testLegacyMatchRules = {
 
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains a %(name)s string in it.',
-                targetLocale: "de-DE",
-                target: "Diese Zeichenfolge enthält keinen anderen Zeichenfolgen.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains a %(name)s string in it.',
+                    targetLocale: "de-DE",
+                    target: "Diese Zeichenfolge enthält keinen anderen Zeichenfolgen.",
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         // if the source contains native quotes, the target must too
         const expected = new Result({
@@ -122,15 +125,18 @@ export const testLegacyMatchRules = {
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains “quotes” in it.',
-                targetLocale: "de-DE",
-                target: 'Diese Zeichenfolge enthält "Anführungszeichen".',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains “quotes” in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält "Anführungszeichen".',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 
@@ -145,15 +151,18 @@ export const testLegacyMatchRules = {
 
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains a name string in it.',
-                targetLocale: "de-DE",
-                target: "Diese Zeichenfolge enthält %(name)s anderen Zeichenfolgen %(name)s.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains a name string in it.',
+                    targetLocale: "de-DE",
+                    target: "Diese Zeichenfolge enthält %(name)s anderen Zeichenfolgen %(name)s.",
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         // if the source contains native quotes, the target must too
         const expected = [
@@ -190,15 +199,18 @@ export const testLegacyMatchRules = {
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains %(name)s in it.',
-                targetLocale: "de-DE",
-                target: 'Diese Zeichenfolge enthält %(name)s.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains %(name)s in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält %(name)s.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 
@@ -214,15 +226,18 @@ export const testLegacyMatchRules = {
         // whitespace in parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains %( name )s in it.',
-                targetLocale: "de-DE",
-                target: 'Diese Zeichenfolge enthält %(name)s.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains %( name )s in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält %(name)s.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 
@@ -238,15 +253,18 @@ export const testLegacyMatchRules = {
         // whitespace in parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains %(name)s in it.',
-                targetLocale: "de-DE",
-                target: 'Diese Zeichenfolge enthält %( name )s.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains %(name)s in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält %( name )s.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 
@@ -262,15 +280,18 @@ export const testLegacyMatchRules = {
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string %(number)d contains %(name)s in it.',
-                targetLocale: "de-DE",
-                target: 'Diese Zeichenfolge enthält %(name)s %(number)d.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string %(number)d contains %(name)s in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält %(name)s %(number)d.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 


### PR DESCRIPTION
- now uses the IntermediateRepresentation

I would recommend ignoring whitespace differences while looking at the diff, as much of it was merely indented.