### PR TITLE
Make sure to ignore strings with double curly braces

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.1.1
+
+- fixed a bug where doubled curly braces (= escaped curly braces) were
+  interpreted as replacement parameters
+
 ### v1.1.0
 
 - updated dependencies

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ limitations under the License.
 
 - fixed a bug where doubled curly braces (= escaped curly braces) were
   interpreted as replacement parameters
+- updated dependencies
 
 ### v1.1.0
 

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
         "npm-run-all": "^4.1.5"
     },
     "dependencies": {
-        "i18nlint-common": "^2.1.0",
+        "i18nlint-common": "^2.2.0",
         "ilib-locale": "^1.2.2",
-        "ilib-tools-common": "^1.7.0"
+        "ilib-tools-common": "^1.8.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint-python",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "main": "./src/index.js",
     "type": "module",
     "exports": {

--- a/src/FStringMatchRule.js
+++ b/src/FStringMatchRule.js
@@ -59,11 +59,13 @@ class FStringMatchRule extends Rule {
         fstringRegExp.lastIndex = 0;
         match = fstringRegExp.exec(src);
         while (match) {
-            sourceParams.push({
-                text: match[0],
-                name: match[1],
-                number: match[2]
-            });
+            if (!match[0].startsWith("{{")) {
+                sourceParams.push({
+                    text: match[0],
+                    name: match[1],
+                    number: match[2]
+                });
+            }
             match = fstringRegExp.exec(src);
         }
         if (sourceParams.length < 1) {
@@ -75,11 +77,13 @@ class FStringMatchRule extends Rule {
         fstringRegExp.lastIndex = 0;
         match = fstringRegExp.exec(tar);
         while (match) {
-            targetParams.push({
-                text: match[0],
-                name: match[1],
-                number: match[2]
-            });
+            if (!match[0].startsWith("{{")) {
+                targetParams.push({
+                    text: match[0],
+                    name: match[1],
+                    number: match[2]
+                });
+            }
             match = fstringRegExp.exec(tar);
         }
 

--- a/test/testFStringMatchRule.js
+++ b/test/testFStringMatchRule.js
@@ -233,7 +233,7 @@ export const testFStringMatchRules = {
         test.done();
     },
 
-    testFStringMatchRuleMatchMatchingParamsIgnoreWhitespaceInTarget: function(test) {
+    testFStringMatchRuleMatchMatchingParamsIgnoreWhitespaceInTarget1: function(test) {
         test.expect(2);
 
         const rule = new FStringMatchRule();
@@ -250,6 +250,60 @@ export const testFStringMatchRules = {
                     source: 'This string contains {name} in it.',
                     targetLocale: "de-DE",
                     target: 'Diese Zeichenfolge enthält { name }.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testFStringMatchRuleMatchMatchingParamsIgnoreWhitespaceInTarget2: function(test) {
+        test.expect(2);
+
+        const rule = new FStringMatchRule();
+        test.ok(rule);
+
+        // whitespace in parameters in source or target is okay
+        const actual = rule.match({
+            locale: "de-DE",
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains {name} in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält { name}.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testFStringMatchRuleMatchMatchingParamsIgnoreWhitespaceInTarget3: function(test) {
+        test.expect(2);
+
+        const rule = new FStringMatchRule();
+        test.ok(rule);
+
+        // whitespace in parameters in source or target is okay
+        const actual = rule.match({
+            locale: "de-DE",
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains {name} in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält {name }.',
                     pathName: "a/b/c.xliff"
                 })],
                 filePath: "x"
@@ -482,6 +536,90 @@ export const testFStringMatchRules = {
         test.deepEqual(actual, expected);
 
         test.done();
-    }
+    },
+
+    testFStringMatchRuleDoNotMatchDoubleCurlies1: function(test) {
+        test.expect(2);
+
+        const rule = new FStringMatchRule();
+        test.ok(rule);
+
+        // Double curly braces render to a single one in the output
+        // and do not indicate the presence of a replacement param
+        const actual = rule.match({
+            locale: "de-DE",
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains a {{ and a }} character in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält einen {{ und einen }} Zeichen.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testFStringMatchRuleDoNotMatchDoubleCurlies2: function(test) {
+        test.expect(2);
+
+        const rule = new FStringMatchRule();
+        test.ok(rule);
+
+        // Double curly braces render to a single one in the output
+        // and do not indicate the presence of a replacement param
+        const actual = rule.match({
+            locale: "de-DE",
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains a {{and}} character in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält einen {{und}} Zeichen.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testFStringMatchRuleDoNotMatchDoubleCurlies3: function(test) {
+        test.expect(2);
+
+        const rule = new FStringMatchRule();
+        test.ok(rule);
+
+        // Double curly braces render to a single one in the output
+        // and do not indicate the presence of a replacement param
+        const actual = rule.match({
+            locale: "de-DE",
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains a {{and }} character in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält einen {{ und}} Zeichen.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
 };
 

--- a/test/testFStringNumberedRule.js
+++ b/test/testFStringNumberedRule.js
@@ -304,5 +304,54 @@ export const testFStringNumberedRules = {
         test.deepEqual(actual, expected);
 
         test.done();
-    }
+    },
+
+    testFStringNumberedRuleIgnoreDoubleCurlies1: function(test) {
+        test.expect(2);
+
+        const rule = new FStringNumberedRule();
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "de-DE",
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "fstring.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains a {{}} string in it.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testFStringNumberedRuleIgnoreDoubleCurlies2: function(test) {
+        test.expect(2);
+
+        const rule = new FStringNumberedRule();
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "de-DE",
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "fstring.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains a {{ }} string in it.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
 };


### PR DESCRIPTION
Double curly braces are rendered as a single curly brace in the output, and do not indicate a replacement parameter. As such, they should be ignored.