### PR TITLE
Update from i18nlint-common to ilib-lint-common

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ file types.
 
 ## License
 
-Copyright © 2023, JEDLSoft
+Copyright © 2023-2024, JEDLSoft
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -68,6 +68,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ## Release Notes
+
+### v2.0.0
+
+- Updated dependency from i18nlint-common to ilib-lint-common
+    - IntermediateRepresentation now takes a SourceFile as an
+      parameter to the constructor instead of a file path
+    - can now be loaded by ilib-lint >= v2
 
 ### v1.1.2
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "exports": {
         ".": {
             "import": "./src/index.js"
+        },
+        "package.json": {
+            "import": "./package.json"
         }
     },
     "description": "ilib-lint plugin to check python",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint-python",
-    "version": "1.1.2",
+    "version": "2.0.0",
     "main": "./src/index.js",
     "type": "module",
     "exports": {
@@ -32,12 +32,12 @@
         "docdash": "^2.0.2",
         "jest": "^29.7.0",
         "jsdoc": "^4.0.2",
-        "jsdoc-to-markdown": "^8.0.0",
+        "jsdoc-to-markdown": "^8.0.1",
         "npm-run-all": "^4.1.5"
     },
     "dependencies": {
-        "i18nlint-common": "^2.2.0",
+        "ilib-lint-common": "^3.0.0",
         "ilib-locale": "^1.2.2",
-        "ilib-tools-common": "^1.8.0"
+        "ilib-tools-common": "^1.9.1"
     }
 }

--- a/src/FStringMatchRule.js
+++ b/src/FStringMatchRule.js
@@ -1,7 +1,7 @@
 /*
  * FStringMatchRule.js - implement a rule to match f-string substitution parameters
  *
- * Copyright © 2023 JEDLSoft
+ * Copyright © 2023-2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
  */
 
 import Locale from 'ilib-locale';
-import { Rule, Result } from 'i18nlint-common';
+import { Rule, Result } from 'ilib-lint-common';
 
 // from https://peps.python.org/pep-0498/
 const fstringRegExp = /\{\s*((\}\}|[^}])*?)\s*\}/g;
@@ -147,7 +147,7 @@ class FStringMatchRule extends Rule {
                 case 'string':
                     const tarString = resource.getTarget();
                     if (tarString) {
-                        return this.checkString(resource.getSource(), tarString, ir.getPath(), resource, options.lineNumber);
+                        return this.checkString(resource.getSource(), tarString, ir.sourceFile.getPath(), resource, options.lineNumber);
                     }
                     break;
 
@@ -157,7 +157,7 @@ class FStringMatchRule extends Rule {
                     if (tarArray) {
                         return srcArray.flatMap((item, i) => {
                             if (i < tarArray.length && tarArray[i]) {
-                                return this.checkString(srcArray[i], tarArray[i], ir.getPath(), resource, options.lineNumber);
+                                return this.checkString(srcArray[i], tarArray[i], ir.sourceFile.getPath(), resource, options.lineNumber);
                             }
                         }).filter(element => {
                             return element;
@@ -171,7 +171,7 @@ class FStringMatchRule extends Rule {
                     if (tarPlural) {
                         const categories = Array.from(new Set(Object.keys(srcPlural).concat(Object.keys(tarPlural))).values());
                         return categories.flatMap(category => {
-                            return this.checkString(srcPlural[category] || srcPlural.other, tarPlural[category] || tarPlural.other, ir.getPath(), resource, options.lineNumber);
+                            return this.checkString(srcPlural[category] || srcPlural.other, tarPlural[category] || tarPlural.other, ir.sourceFile.getPath(), resource, options.lineNumber);
                         });
                     }
                     break;

--- a/src/FStringNumberedRule.js
+++ b/src/FStringNumberedRule.js
@@ -1,7 +1,7 @@
 /*
  * TestRule.js - test an i18nlint Rule plugin
  *
- * Copyright © 2023 JEDLSoft
+ * Copyright © 2023-2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
  */
 
 import Locale from 'ilib-locale';
-import { Rule, Result } from 'i18nlint-common';
+import { Rule, Result } from 'ilib-lint-common';
 
 // from https://pubs.opengroup.org/onlinepubs/007904975/functions/fprintf.html
 const fstringRegExp = /\{(\}\}|[^}])*?\}/g;
@@ -92,13 +92,13 @@ class FStringNumberedRule extends Rule {
         const results = resources.flatMap(resource => {
             switch (resource.getType()) {
                 case 'string':
-                    return this.checkString(resource.getSource(), ir.getPath(), resource, options.lineNumber);
+                    return this.checkString(resource.getSource(), ir.sourceFile.getPath(), resource, options.lineNumber);
                     break;
 
                 case 'array':
                     const srcArray = resource.getSource();
                     return srcArray.flatMap(item => {
-                        return this.checkString(item, ir.getPath(), resource, options.lineNumber);
+                        return this.checkString(item, ir.sourceFile.getPath(), resource, options.lineNumber);
                     }).filter(element => {
                         return element;
                     });
@@ -108,7 +108,7 @@ class FStringNumberedRule extends Rule {
                     const srcPlural = resource.getSource();
                     const categories = Object.keys(srcPlural);
                     return categories.flatMap(category => {
-                        return this.checkString(srcPlural[category], ir.getPath(), resource, options.lineNumber);
+                        return this.checkString(srcPlural[category], ir.sourceFile.getPath(), resource, options.lineNumber);
                     });
                     break;
             }

--- a/src/LegacyMatchRule.js
+++ b/src/LegacyMatchRule.js
@@ -1,7 +1,7 @@
 /*
  * TestRule.js - test an i18nlint Rule plugin
  *
- * Copyright © 2023 JEDLSoft
+ * Copyright © 2023-2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
  */
 
 import Locale from 'ilib-locale';
-import { Rule, Result } from 'i18nlint-common';
+import { Rule, Result } from 'ilib-lint-common';
 
 // from https://pubs.opengroup.org/onlinepubs/007904975/functions/fprintf.html
 const printfRegExp = /%\(\s*(\w+)\s*\)?[\-\+ #0']*[\d\*]?(\.(\d*|\*))?(hh?|ll?|j|z|t|L)?[diouxXfFeEgGaAcCsSpn]/g;
@@ -135,7 +135,7 @@ class LegacyMatchRule extends Rule {
                 case 'string':
                     const tarString = resource.getTarget();
                     if (tarString) {
-                        return this.checkString(resource.getSource(), tarString, ir.getPath(), resource, sourceLocale, locale, options.lineNumber);
+                        return this.checkString(resource.getSource(), tarString, ir.sourceFile.getPath(), resource, sourceLocale, locale, options.lineNumber);
                     }
                     break;
 
@@ -145,7 +145,7 @@ class LegacyMatchRule extends Rule {
                     if (tarArray) {
                         return srcArray.flatMap((item, i) => {
                             if (i < tarArray.length && tarArray[i]) {
-                                return this.checkString(srcArray[i], tarArray[i], ir.getPath(), resource, sourceLocale, locale, options.lineNumber);
+                                return this.checkString(srcArray[i], tarArray[i], ir.sourceFile.getPath(), resource, sourceLocale, locale, options.lineNumber);
                             }
                         }).filter(element => {
                             return element;
@@ -158,7 +158,7 @@ class LegacyMatchRule extends Rule {
                     const tarPlural = resource.getTarget();
                     if (tarPlural) {
                         return categories.flatMap(category => {
-                            return this.checkString(srcPlural.other, tarPlural[category], ir.getPath(), resource, sourceLocale, locale, options.lineNumber);
+                            return this.checkString(srcPlural.other, tarPlural[category], ir.sourceFile.getPath(), resource, sourceLocale, locale, options.lineNumber);
                         });
                     }
                     break;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js - main program of python gnu plugin
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { Plugin } from 'i18nlint-common';
+import { Plugin } from 'ilib-lint-common';
 
 import FStringMatchRule from './FStringMatchRule.js';
 import FStringNumberedRule from './FStringNumberedRule.js';

--- a/test/FStringMatchRule.test.js
+++ b/test/FStringMatchRule.test.js
@@ -1,7 +1,7 @@
 /*
  * FStringMatchRule.test.js - test the substitution parameter rule
  *
- * Copyright © 2023 JEDLSoft
+ * Copyright © 2023-2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import { ResourceString } from 'ilib-tools-common';
 
 import FStringMatchRule from '../src/FStringMatchRule.js';
 
-import { Result, IntermediateRepresentation } from 'i18nlint-common';
+import { Result, IntermediateRepresentation, SourceFile } from 'ilib-lint-common';
 
 describe("testFStringMatchRules", () => {
     test("FStringMatchRuleStyle", () => {
@@ -76,6 +76,7 @@ describe("testFStringMatchRules", () => {
         const rule = new FStringMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         const actual = rule.match({
             locale: "de-DE",
             ir: new IntermediateRepresentation({
@@ -88,7 +89,7 @@ describe("testFStringMatchRules", () => {
                     target: "Diese Zeichenfolge enthält keinen anderen Zeichenfolgen.",
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         // if the source contains native quotes, the target must too
@@ -99,7 +100,7 @@ describe("testFStringMatchRules", () => {
             source: 'This string contains a {name} string in it.',
             highlight: '<e0>Diese Zeichenfolge enthält keinen anderen Zeichenfolgen.</e0>',
             rule,
-            pathName: "x"
+            pathName: "a/b/c.xliff"
         });
         expect(actual).toStrictEqual(expected);
     });
@@ -110,6 +111,7 @@ describe("testFStringMatchRules", () => {
         const rule = new FStringMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -123,7 +125,7 @@ describe("testFStringMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält "Anführungszeichen".',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -135,6 +137,7 @@ describe("testFStringMatchRules", () => {
         const rule = new FStringMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         const actual = rule.match({
             locale: "de-DE",
             ir: new IntermediateRepresentation({
@@ -147,7 +150,7 @@ describe("testFStringMatchRules", () => {
                     target: "Diese Zeichenfolge enthält {name} anderen Zeichenfolgen {name}.",
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         // if the source contains native quotes, the target must too
@@ -158,7 +161,7 @@ describe("testFStringMatchRules", () => {
             source: 'This string contains a {name} string in it.',
             highlight: 'Diese Zeichenfolge enthält <e0>{name}</e0> anderen Zeichenfolgen <e0>{name}</e0>.',
             rule,
-            pathName: "x"
+            pathName: "a/b/c.xliff"
         });
         expect(actual).toStrictEqual(expected);
     });
@@ -169,6 +172,7 @@ describe("testFStringMatchRules", () => {
         const rule = new FStringMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -182,7 +186,7 @@ describe("testFStringMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält {name}.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -194,6 +198,7 @@ describe("testFStringMatchRules", () => {
         const rule = new FStringMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // whitespace in parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -207,7 +212,7 @@ describe("testFStringMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält {name}.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -219,6 +224,7 @@ describe("testFStringMatchRules", () => {
         const rule = new FStringMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // whitespace in parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -232,7 +238,7 @@ describe("testFStringMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält { name }.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -244,6 +250,7 @@ describe("testFStringMatchRules", () => {
         const rule = new FStringMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // whitespace in parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -257,7 +264,7 @@ describe("testFStringMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält { name}.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -269,6 +276,7 @@ describe("testFStringMatchRules", () => {
         const rule = new FStringMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // whitespace in parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -282,7 +290,7 @@ describe("testFStringMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält {name }.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -294,6 +302,7 @@ describe("testFStringMatchRules", () => {
         const rule = new FStringMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -307,7 +316,7 @@ describe("testFStringMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält {name} {number}.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -319,6 +328,7 @@ describe("testFStringMatchRules", () => {
         const rule = new FStringMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -332,7 +342,7 @@ describe("testFStringMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält {number:.3d}.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -344,6 +354,7 @@ describe("testFStringMatchRules", () => {
         const rule = new FStringMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -357,7 +368,7 @@ describe("testFStringMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält {number:3.3d}.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         const expected = [
@@ -368,7 +379,7 @@ describe("testFStringMatchRules", () => {
                 source: 'This string contains {number:.3d} in it.',
                 highlight: '<e0>Diese Zeichenfolge enthält {number:3.3d}.</e0>',
                 rule,
-                pathName: "x"
+                pathName: "a/b/c.xliff"
             }),
             new Result({
                 severity: "error",
@@ -377,7 +388,7 @@ describe("testFStringMatchRules", () => {
                 source: 'This string contains {number:.3d} in it.',
                 highlight: 'Diese Zeichenfolge enthält <e0>{number:3.3d}</e0>.',
                 rule,
-                pathName: "x"
+                pathName: "a/b/c.xliff"
             })
         ];
         expect(actual).toStrictEqual(expected);
@@ -389,6 +400,7 @@ describe("testFStringMatchRules", () => {
         const rule = new FStringMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // numeric params in source and target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -402,7 +414,7 @@ describe("testFStringMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält {0}.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -414,6 +426,7 @@ describe("testFStringMatchRules", () => {
         const rule = new FStringMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         const actual = rule.match({
             locale: "de-DE",
             ir: new IntermediateRepresentation({
@@ -426,7 +439,7 @@ describe("testFStringMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält {name}.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(actual).toBeTruthy();
@@ -439,7 +452,7 @@ describe("testFStringMatchRules", () => {
                 source: 'This string contains {0} in it.',
                 highlight: '<e0>Diese Zeichenfolge enthält {name}.</e0>',
                 rule,
-                pathName: "x"
+                pathName: "a/b/c.xliff"
             }),
             new Result({
                 severity: "error",
@@ -448,7 +461,7 @@ describe("testFStringMatchRules", () => {
                 source: 'This string contains {0} in it.',
                 highlight: 'Diese Zeichenfolge enthält <e0>{name}</e0>.',
                 rule,
-                pathName: "x"
+                pathName: "a/b/c.xliff"
             }),
         ];
         expect(actual).toStrictEqual(expected);
@@ -460,6 +473,7 @@ describe("testFStringMatchRules", () => {
         const rule = new FStringMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         const actual = rule.match({
             locale: "de-DE",
             ir: new IntermediateRepresentation({
@@ -472,7 +486,7 @@ describe("testFStringMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält {0}.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(actual).toBeTruthy();
@@ -485,7 +499,7 @@ describe("testFStringMatchRules", () => {
                 source: 'This string contains {name} in it.',
                 highlight: '<e0>Diese Zeichenfolge enthält {0}.</e0>',
                 rule,
-                pathName: "x"
+                pathName: "a/b/c.xliff"
             }),
             new Result({
                 severity: "error",
@@ -494,7 +508,7 @@ describe("testFStringMatchRules", () => {
                 source: 'This string contains {name} in it.',
                 highlight: 'Diese Zeichenfolge enthält <e0>{0}</e0>.',
                 rule,
-                pathName: "x"
+                pathName: "a/b/c.xliff"
             }),
         ];
         expect(actual).toStrictEqual(expected);
@@ -506,6 +520,7 @@ describe("testFStringMatchRules", () => {
         const rule = new FStringMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // Double curly braces render to a single one in the output
         // and do not indicate the presence of a replacement param
         const actual = rule.match({
@@ -520,7 +535,7 @@ describe("testFStringMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält einen {{ und einen }} Zeichen.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -532,6 +547,7 @@ describe("testFStringMatchRules", () => {
         const rule = new FStringMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // Double curly braces render to a single one in the output
         // and do not indicate the presence of a replacement param
         const actual = rule.match({
@@ -546,7 +562,7 @@ describe("testFStringMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält einen {{und}} Zeichen.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -558,6 +574,7 @@ describe("testFStringMatchRules", () => {
         const rule = new FStringMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // Double curly braces render to a single one in the output
         // and do not indicate the presence of a replacement param
         const actual = rule.match({
@@ -572,7 +589,7 @@ describe("testFStringMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält einen {{ und}} Zeichen.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();

--- a/test/FStringNumberedRule.test.js
+++ b/test/FStringNumberedRule.test.js
@@ -1,7 +1,7 @@
 /*
  * FStringNumberedRule.test.js - test the substitution parameter numbering rule
  *
- * Copyright © 2023 JEDLSoft
+ * Copyright © 2023-2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import { ResourceString } from 'ilib-tools-common';
-import { Result, IntermediateRepresentation } from 'i18nlint-common';
+import { Result, IntermediateRepresentation, SourceFile } from 'ilib-lint-common';
 
 import FStringNumberedRule from '../src/FStringNumberedRule.js';
 
@@ -75,6 +75,7 @@ describe("testFStringNumberedRules", () => {
         const rule = new FStringNumberedRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         const actual = rule.match({
             locale: "de-DE",
             ir: new IntermediateRepresentation({
@@ -85,7 +86,7 @@ describe("testFStringNumberedRules", () => {
                     source: 'This {} string contains a {} string in it.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         // if the source contains native quotes, the target must too
@@ -96,7 +97,7 @@ describe("testFStringNumberedRules", () => {
                 id: "fstring.test",
                 highlight: 'This <e0>{}</e0> string contains a <e0>{}</e0> string in it.',
                 rule,
-                pathName: "x"
+                pathName: "a/b/c.xliff"
             }),
             new Result({
                 severity: "error",
@@ -104,7 +105,7 @@ describe("testFStringNumberedRules", () => {
                 id: "fstring.test",
                 highlight: 'This <e0>{}</e0> string contains a <e0>{}</e0> string in it.',
                 rule,
-                pathName: "x"
+                pathName: "a/b/c.xliff"
             })
         ];
         expect(actual).toStrictEqual(expected);
@@ -116,6 +117,7 @@ describe("testFStringNumberedRules", () => {
         const rule = new FStringNumberedRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -127,7 +129,7 @@ describe("testFStringNumberedRules", () => {
                     source: 'This string contains no substitution parameters in it.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -139,6 +141,7 @@ describe("testFStringNumberedRules", () => {
         const rule = new FStringNumberedRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -150,7 +153,7 @@ describe("testFStringNumberedRules", () => {
                     source: 'This string contains a {name} substitution parameter in it.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -162,6 +165,7 @@ describe("testFStringNumberedRules", () => {
         const rule = new FStringNumberedRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -173,7 +177,7 @@ describe("testFStringNumberedRules", () => {
                     source: 'This string contains a {} substitution parameter in it.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -185,6 +189,7 @@ describe("testFStringNumberedRules", () => {
         const rule = new FStringNumberedRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         const actual = rule.match({
             locale: "de-DE",
             ir: new IntermediateRepresentation({
@@ -195,7 +200,7 @@ describe("testFStringNumberedRules", () => {
                     source: 'This {name} string contains a {} string in it.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         // if the source contains native quotes, the target must too
@@ -205,7 +210,7 @@ describe("testFStringNumberedRules", () => {
             id: "fstring.test",
             highlight: 'This {name} string contains a <e0>{}</e0> string in it.',
             rule,
-            pathName: "x"
+            pathName: "a/b/c.xliff"
         });
         expect(actual).toStrictEqual(expected);
     });
@@ -216,6 +221,7 @@ describe("testFStringNumberedRules", () => {
         const rule = new FStringNumberedRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         const actual = rule.match({
             locale: "de-DE",
             ir: new IntermediateRepresentation({
@@ -226,7 +232,7 @@ describe("testFStringNumberedRules", () => {
                     source: 'This {name} string contains a {} string in {location}.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         // if the source contains native quotes, the target must too
@@ -236,7 +242,7 @@ describe("testFStringNumberedRules", () => {
             id: "fstring.test",
             highlight: 'This {name} string contains a <e0>{}</e0> string in {location}.',
             rule,
-            pathName: "x"
+            pathName: "a/b/c.xliff"
         });
         expect(actual).toStrictEqual(expected);
     });
@@ -247,6 +253,7 @@ describe("testFStringNumberedRules", () => {
         const rule = new FStringNumberedRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         const actual = rule.match({
             locale: "de-DE",
             ir: new IntermediateRepresentation({
@@ -257,7 +264,7 @@ describe("testFStringNumberedRules", () => {
                     source: 'This {name} string contains a {} string in {}.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         // if the source contains native quotes, the target must too
@@ -268,7 +275,7 @@ describe("testFStringNumberedRules", () => {
                 id: "fstring.test",
                 highlight: 'This {name} string contains a <e0>{}</e0> string in <e0>{}</e0>.',
                 rule,
-                pathName: "x"
+                pathName: "a/b/c.xliff"
             }),
             new Result({
                 severity: "error",
@@ -276,7 +283,7 @@ describe("testFStringNumberedRules", () => {
                 id: "fstring.test",
                 highlight: 'This {name} string contains a <e0>{}</e0> string in <e0>{}</e0>.',
                 rule,
-                pathName: "x"
+                pathName: "a/b/c.xliff"
             })
         ];
         expect(actual).toStrictEqual(expected);
@@ -288,6 +295,7 @@ describe("testFStringNumberedRules", () => {
         const rule = new FStringNumberedRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         const actual = rule.match({
             locale: "de-DE",
             ir: new IntermediateRepresentation({
@@ -298,7 +306,7 @@ describe("testFStringNumberedRules", () => {
                     source: 'This string contains a {{}} string in it.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -310,6 +318,7 @@ describe("testFStringNumberedRules", () => {
         const rule = new FStringNumberedRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         const actual = rule.match({
             locale: "de-DE",
             ir: new IntermediateRepresentation({
@@ -320,7 +329,7 @@ describe("testFStringNumberedRules", () => {
                     source: 'This string contains a {{ }} string in it.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();

--- a/test/LegacyMatchRule.test.js
+++ b/test/LegacyMatchRule.test.js
@@ -1,7 +1,7 @@
 /*
  * LegacyMatchRule.test.js - test the substitution parameter rule
  *
- * Copyright © 2023 JEDLSoft
+ * Copyright © 2023-2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import { ResourceString } from 'ilib-tools-common';
 
 import LegacyMatchRule from '../src/LegacyMatchRule.js';
 
-import { Result, IntermediateRepresentation } from 'i18nlint-common';
+import { Result, IntermediateRepresentation, SourceFile } from 'ilib-lint-common';
 
 describe("testLegacyMatchRules", () => {
     test("LegacyMatchRuleStyle", () => {
@@ -76,6 +76,7 @@ describe("testLegacyMatchRules", () => {
         const rule = new LegacyMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         const actual = rule.match({
             locale: "de-DE",
             ir: new IntermediateRepresentation({
@@ -88,7 +89,7 @@ describe("testLegacyMatchRules", () => {
                     target: "Diese Zeichenfolge enthält keinen anderen Zeichenfolgen.",
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         // if the source contains native quotes, the target must too
@@ -99,7 +100,7 @@ describe("testLegacyMatchRules", () => {
             source: 'This string contains a %(name)s string in it.',
             highlight: '<e0>Diese Zeichenfolge enthält keinen anderen Zeichenfolgen.</e0>',
             rule,
-            pathName: "x"
+            pathName: "a/b/c.xliff"
         });
         expect(actual).toStrictEqual(expected);
     });
@@ -110,6 +111,7 @@ describe("testLegacyMatchRules", () => {
         const rule = new LegacyMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -123,7 +125,7 @@ describe("testLegacyMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält "Anführungszeichen".',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -135,6 +137,7 @@ describe("testLegacyMatchRules", () => {
         const rule = new LegacyMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         const actual = rule.match({
             locale: "de-DE",
             ir: new IntermediateRepresentation({
@@ -147,7 +150,7 @@ describe("testLegacyMatchRules", () => {
                     target: "Diese Zeichenfolge enthält %(name)s anderen Zeichenfolgen %(name)s.",
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         // if the source contains native quotes, the target must too
@@ -159,7 +162,7 @@ describe("testLegacyMatchRules", () => {
                 source: 'This string contains a name string in it.',
                 highlight: 'Diese Zeichenfolge enthält <e0>%(name)s</e0> anderen Zeichenfolgen <e0>%(name)s</e0>.',
                 rule,
-                pathName: "x"
+                pathName: "a/b/c.xliff"
             }),
             new Result({
                 severity: "error",
@@ -168,7 +171,7 @@ describe("testLegacyMatchRules", () => {
                 source: 'This string contains a name string in it.',
                 highlight: 'Diese Zeichenfolge enthält <e0>%(name)s</e0> anderen Zeichenfolgen <e0>%(name)s</e0>.',
                 rule,
-                pathName: "x"
+                pathName: "a/b/c.xliff"
             })
         ];
         expect(actual).toStrictEqual(expected);
@@ -180,6 +183,7 @@ describe("testLegacyMatchRules", () => {
         const rule = new LegacyMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -193,7 +197,7 @@ describe("testLegacyMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält %(name)s.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -205,6 +209,7 @@ describe("testLegacyMatchRules", () => {
         const rule = new LegacyMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // whitespace in parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -218,7 +223,7 @@ describe("testLegacyMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält %(name)s.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -230,6 +235,7 @@ describe("testLegacyMatchRules", () => {
         const rule = new LegacyMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // whitespace in parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -243,7 +249,7 @@ describe("testLegacyMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält %( name )s.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -255,6 +261,7 @@ describe("testLegacyMatchRules", () => {
         const rule = new LegacyMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -268,7 +275,7 @@ describe("testLegacyMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält %(name)s %(number)d.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();

--- a/test/PythonPlugin.test.js
+++ b/test/PythonPlugin.test.js
@@ -1,7 +1,7 @@
 /*
  * PythonGnuPlugin.test.js - test the Xliff plugin
  *
- * Copyright © 2023 JEDLSoft
+ * Copyright © 2023-2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Parser } from 'i18nlint-common';
+import { Parser } from 'ilib-lint-common';
 
 import PythonPlugin from '../src/index.js';
 


### PR DESCRIPTION
- Updated dependency from i18nlint-common to ilib-lint-common
    - IntermediateRepresentation now takes a SourceFile as an
      parameter to the constructor instead of a file path
    - can now be loaded by ilib-lint >= v2
- do not merge until I test it with ilib-lint itself